### PR TITLE
Add support for running in podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ endif
 	touch .build
 
 shell: .check .build
+ifdef PODMAN
+	$(TOOL) run -it --rm -v "$(WORKSPACE_DIR)":/root/workspace:z $(TOOLCHAIN_NAME) /bin/bash
+else
 	$(TOOL) run -it --rm -v "$(WORKSPACE_DIR)":/root/workspace $(TOOLCHAIN_NAME) /bin/bash
+endif
 
 clean: .check
 	$(TOOL) rmi $(TOOLCHAIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,27 @@
 	
 TOOLCHAIN_NAME=miyoomini-toolchain
 WORKSPACE_DIR := $(shell pwd)/workspace
+TOOL=
+DOCKER := $(shell command -v docker 2> /dev/null)
+PODMAN := $(shell command -v podman 2> /dev/null)
 
-.build: Dockerfile
+.check:
+ifdef DOCKER
+    TOOL=docker
+else ifdef PODMAN
+    TOOL=podman
+else
+    $(error "Docker or Podman must be installed!")
+endif
+
+.build: .check Dockerfile
 	mkdir -p ./workspace
-	docker build -t $(TOOLCHAIN_NAME) .
+	$(TOOL) build -t $(TOOLCHAIN_NAME) .
 	touch .build
 
-shell: .build
-	docker run -it --rm -v "$(WORKSPACE_DIR)":/root/workspace $(TOOLCHAIN_NAME) /bin/bash
+shell: .check .build
+	$(TOOL) run -it --rm -v "$(WORKSPACE_DIR)":/root/workspace $(TOOLCHAIN_NAME) /bin/bash
 
-clean:
-	docker rmi $(TOOLCHAIN_NAME)
+clean: .check
+	$(TOOL) rmi $(TOOLCHAIN_NAME)
 	rm -f .build


### PR DESCRIPTION
This commit adds support for running the toolchain in podman, but defaults to Docker if both are installed. It also returns an error
message if neither is installed.